### PR TITLE
feat: add level config to control logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ To use a logger, you must first create one:
 import { ConsoleLogger } from "https://deno.land/x/unilogger@v1.0.1/mod.ts";
 import { FileLogger } from "https://deno.land/x/unilogger@v1.0.1/mod.ts";
 
-const consoleLogger = new ConsoleLogger();
-const fileLogger = new FileLogger({ file: "file.log" }); // NOTE: `file` is request here, it's the filename which logging will be sent to
+const consoleLogger = new ConsoleLogger({});
+const fileLogger = new FileLogger({ file: "file.log" }); // NOTE: `file` is required here, it's the filename which logging will be sent to
 ```
 
 ## Using a Logger
@@ -30,8 +30,9 @@ const fileLogger = new FileLogger({ file: "file.log" }); // NOTE: `file` is requ
 Both logger types provide the same API methods. The only difference is, one logs
 to the console, one logs to a file.
 
-Within the constructor, you can pass in `tag_string` and `tag_string_fns`. Both
-of these allow you to pass in custom data to the message if you wish to:
+Within the constructor, you can pass in `level`, `tag_string` and
+`tag_string_fns`. Both of these allow you to pass in custom data to the message
+if you wish to:
 
 ```ts
 const logger = new ConsoleLogger({ // or FileLogger
@@ -44,8 +45,27 @@ const logger = new ConsoleLogger({ // or FileLogger
       return "The Moon";
     },
   },
+  level: "error", // will log any calls to `error()` and `fatal()`
 });
 ```
 
 Then calling `logger.info("Hello")` (or any other method) will display
 `[INFO] Drashland | The Moon | Hello`
+
+You can check the
+[API Reference](https://doc.deno.land/https/deno.land/x/unilogger/mod.ts) for
+what is acceptable to pass to `level`. Below is what levels will log which
+types:
+
+```
+all: logs all messages
+trace: logs trace, debug, info, warn, error, fatal
+debug: logs debug, info, warn, error, fatal
+info: logs info, warn, error, fatal
+warn: logs warn, error, fatal,
+error: logs error, fatal
+fatal: logs fatal
+off: does not log any messages
+```
+
+So this means that a `logger.warn("hello")` will not log if `level` is `error`.

--- a/src/console_logger.ts
+++ b/src/console_logger.ts
@@ -88,6 +88,9 @@ export class ConsoleLogger extends Logger {
     if (!this.shouldLog(logType)) {
       return;
     }
+
+    this.current_log_message_level_name = logType;
+
     const fullLogMessage = this.constructFullLogMessage(message, logType);
     console.log(fullLogMessage);
     return fullLogMessage;

--- a/src/console_logger.ts
+++ b/src/console_logger.ts
@@ -12,8 +12,8 @@ export class ConsoleLogger extends Logger {
    *
    * @returns The full message that will be logged
    */
-  public debug(message: string): string {
-    return this.logToConsole(message, "debug");
+  public debug(message: string): string | void {
+    return this.#logToConsole(message, "debug");
   }
 
   /**
@@ -23,8 +23,8 @@ export class ConsoleLogger extends Logger {
    *
    * @returns The full message that will be logged
    */
-  public error(message: string): string {
-    return this.logToConsole(message, "error");
+  public error(message: string): string | void {
+    return this.#logToConsole(message, "error");
   }
 
   /**
@@ -34,8 +34,8 @@ export class ConsoleLogger extends Logger {
    *
    * @returns The full message that will be logged
    */
-  public info(message: string): string {
-    return this.logToConsole(message, "info");
+  public info(message: string): string | void {
+    return this.#logToConsole(message, "info");
   }
 
   /**
@@ -45,8 +45,8 @@ export class ConsoleLogger extends Logger {
    *
    * @returns The full message that will be logged
    */
-  public warn(message: string): string {
-    return this.logToConsole(message, "warn");
+  public warn(message: string): string | void {
+    return this.#logToConsole(message, "warn");
   }
 
   /**
@@ -56,8 +56,8 @@ export class ConsoleLogger extends Logger {
    *
    * @returns The full message that will be logged
    */
-  public fatal(message: string): string {
-    return this.logToConsole(message, "fatal");
+  public fatal(message: string): string | void {
+    return this.#logToConsole(message, "fatal");
   }
 
   /**
@@ -67,8 +67,8 @@ export class ConsoleLogger extends Logger {
    *
    * @returns The full message that will be logged
    */
-  public trace(message: string): string {
-    return this.logToConsole(message, "trace");
+  public trace(message: string): string | void {
+    return this.#logToConsole(message, "trace");
   }
 
   //////////////////////////////////////////////////////////////////////////////
@@ -84,7 +84,10 @@ export class ConsoleLogger extends Logger {
    *
    * @returns The end message that will be logged
    */
-  private logToConsole(message: string, logType: LogTypes): string {
+  #logToConsole(message: string, logType: LogTypes): string | void {
+    if (!this.shouldLog(logType)) {
+      return;
+    }
     const fullLogMessage = this.constructFullLogMessage(message, logType);
     console.log(fullLogMessage);
     return fullLogMessage;

--- a/src/file_logger.ts
+++ b/src/file_logger.ts
@@ -113,6 +113,9 @@ export class FileLogger extends Logger {
     if (!this.shouldLog(logType)) {
       return;
     }
+
+    this.current_log_message_level_name = logType;
+
     const line = this.constructFullLogMessage(message, logType);
     Deno.writeFileSync(filename, encoder.encode(line + "\n"), { append: true });
     return line;

--- a/src/file_logger.ts
+++ b/src/file_logger.ts
@@ -32,8 +32,8 @@ export class FileLogger extends Logger {
    *
    * @returns The full message that will be logged
    */
-  public debug(message: string): string {
-    return this.logToFile(message, "debug", this.filename);
+  public debug(message: string): string | void {
+    return this.#logToFile(message, "debug", this.filename);
   }
 
   /**
@@ -43,8 +43,8 @@ export class FileLogger extends Logger {
    *
    * @returns The full message that will be logged
    */
-  public error(message: string): string {
-    return this.logToFile(message, "error", this.filename);
+  public error(message: string): string | void {
+    return this.#logToFile(message, "error", this.filename);
   }
 
   /**
@@ -54,8 +54,8 @@ export class FileLogger extends Logger {
    *
    * @returns The full message that will be logged
    */
-  public info(message: string): string {
-    return this.logToFile(message, "info", this.filename);
+  public info(message: string): string | void {
+    return this.#logToFile(message, "info", this.filename);
   }
 
   /**
@@ -65,8 +65,8 @@ export class FileLogger extends Logger {
    *
    * @returns The full message that will be logged
    */
-  public warn(message: string): string {
-    return this.logToFile(message, "warn", this.filename);
+  public warn(message: string): string | void {
+    return this.#logToFile(message, "warn", this.filename);
   }
 
   /**
@@ -76,8 +76,8 @@ export class FileLogger extends Logger {
    *
    * @returns The full message that will be logged
    */
-  public fatal(message: string): string {
-    return this.logToFile(message, "fatal", this.filename);
+  public fatal(message: string): string | void {
+    return this.#logToFile(message, "fatal", this.filename);
   }
 
   /**
@@ -87,8 +87,8 @@ export class FileLogger extends Logger {
    *
    * @returns The full message that will be logged
    */
-  public trace(message: string): string {
-    return this.logToFile(message, "trace", this.filename);
+  public trace(message: string): string | void {
+    return this.#logToFile(message, "trace", this.filename);
   }
 
   //////////////////////////////////////////////////////////////////////////////
@@ -105,11 +105,14 @@ export class FileLogger extends Logger {
    *
    * @returns The end message that will be logged
    */
-  private logToFile(
+  #logToFile(
     message: string,
     logType: LogTypes,
     filename: string,
-  ): string {
+  ): string | void {
+    if (!this.shouldLog(logType)) {
+      return;
+    }
     const line = this.constructFullLogMessage(message, logType);
     Deno.writeFileSync(filename, encoder.encode(line + "\n"), { append: true });
     return line;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -195,6 +195,6 @@ export abstract class Logger {
     }
 
     // Add a space so the log message isn't up against the tag string
-    return tagString + " ";
+    return tagString.trim() + " ";
   }
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -228,7 +228,6 @@ export abstract class Logger {
       );
     }
 
-    // Add a space so the log message isn't up against the tag string
-    return tagString.trim() + " ";
+    return tagString;
   }
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -3,6 +3,7 @@ import { colors } from "../deps.ts";
 type TagStringFunction = (() => string);
 
 export interface LoggerConfigs {
+  level: LogTypes & "all" | "off";
   // deno-lint-ignore camelcase
   tag_string?: string;
   // deno-lint-ignore camelcase
@@ -35,6 +36,10 @@ export abstract class Logger {
    * @param configs - Config used for Logging
    */
   constructor(configs: LoggerConfigs) {
+    if (!configs.level) {
+      configs.level = "debug";
+    }
+
     if (!configs.tag_string) {
       configs.tag_string = "";
     }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -3,7 +3,7 @@ import { colors } from "../deps.ts";
 type TagStringFunction = (() => string);
 
 export interface LoggerConfigs {
-  level: LogTypes & "all" | "off";
+  level?: LogTypes | "all" | "off";
   // deno-lint-ignore camelcase
   tag_string?: string;
   // deno-lint-ignore camelcase
@@ -22,9 +22,19 @@ export abstract class Logger {
   protected configs: LoggerConfigs;
 
   /**
-   * The level of the log message currently being written.
+   * The level of the log message currently being written. This is used to
+   * determine if the message can be logged based on its rank.
    */
-  protected current_log_message_level_name = "";
+  protected current_log_message_level_name!: string;
+
+  protected log_ranks: {[key: string]: number} = {
+    "trace": 6,
+    "debug": 5,
+    "info": 4,
+    "warn": 3,
+    "error": 2,
+    "fatal": 1,
+  };
 
   //////////////////////////////////////////////////////////////////////////////
   // FILE MARKER - CONSTRUCTOR /////////////////////////////////////////////////
@@ -52,7 +62,7 @@ export abstract class Logger {
   }
 
   //////////////////////////////////////////////////////////////////////////////
-  // FILE MARKER - METHODS - ABSTRACT //////////////////////////////////////////
+  // FILE MARKER - METHODS - PUBLIC ////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////
 
   /**
@@ -62,7 +72,7 @@ export abstract class Logger {
    *
    * @returns Return the full logged message.
    */
-  abstract debug(message: string): string;
+  abstract debug(message: string): string | void ;
 
   /**
    * Write a message to the console. Prefixed with the log type
@@ -71,7 +81,7 @@ export abstract class Logger {
    *
    * @returns Return the full logged message.
    */
-  abstract info(message: string): string;
+  abstract info(message: string): string | void ;
 
   /**
    * Write a message to the console. Prefixed with the log type
@@ -80,7 +90,7 @@ export abstract class Logger {
    *
    * @returns Return the full logged message.
    */
-  abstract warn(message: string): string;
+  abstract warn(message: string): string | void ;
 
   /**
    * Write a message to the console. Prefixed with the log type
@@ -89,7 +99,7 @@ export abstract class Logger {
    *
    * @returns Return the full logged message.
    */
-  abstract error(message: string): string;
+  abstract error(message: string): string | void ;
 
   /**
    * Write a message to the console. Prefixed with the log type
@@ -98,7 +108,7 @@ export abstract class Logger {
    *
    * @returns Return the full logged message.
    */
-  abstract trace(message: string): string;
+  abstract trace(message: string): string | void ;
 
   /**
     * Write a message to the console. Prefixed with the log type
@@ -107,7 +117,7 @@ export abstract class Logger {
     *
     * @returns Return the full logged message.
     */
-  abstract fatal(message: string): string;
+  abstract fatal(message: string): string | void ;
 
   //////////////////////////////////////////////////////////////////////////////
   // FILE MARKER - METHODS - PROTECTED /////////////////////////////////////////
@@ -155,6 +165,30 @@ export abstract class Logger {
     }
     message = prefix + " " + message;
     return message;
+  }
+
+  /**
+   * Should the message be logged based on its rank?
+   *
+   * @param logType
+   */
+  protected shouldLog(logType: LogTypes): boolean {
+    if (this.configs.level == "off") {
+      return false;
+    }
+
+    if (this.configs.level == "all") {
+      return true;
+    }
+
+    const messageRank = this.log_ranks[logType];
+    const configRank = this.log_ranks[this.configs.level!];
+
+    if (messageRank <= configRank) {
+      return true;
+    }
+
+    return false;
   }
 
   //////////////////////////////////////////////////////////////////////////////

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -27,7 +27,7 @@ export abstract class Logger {
    */
   protected current_log_message_level_name!: string;
 
-  protected log_ranks: {[key: string]: number} = {
+  protected log_ranks: { [key: string]: number } = {
     "trace": 6,
     "debug": 5,
     "info": 4,
@@ -72,7 +72,7 @@ export abstract class Logger {
    *
    * @returns Return the full logged message.
    */
-  abstract debug(message: string): string | void ;
+  abstract debug(message: string): string | void;
 
   /**
    * Write a message to the console. Prefixed with the log type
@@ -81,7 +81,7 @@ export abstract class Logger {
    *
    * @returns Return the full logged message.
    */
-  abstract info(message: string): string | void ;
+  abstract info(message: string): string | void;
 
   /**
    * Write a message to the console. Prefixed with the log type
@@ -90,7 +90,7 @@ export abstract class Logger {
    *
    * @returns Return the full logged message.
    */
-  abstract warn(message: string): string | void ;
+  abstract warn(message: string): string | void;
 
   /**
    * Write a message to the console. Prefixed with the log type
@@ -99,7 +99,7 @@ export abstract class Logger {
    *
    * @returns Return the full logged message.
    */
-  abstract error(message: string): string | void ;
+  abstract error(message: string): string | void;
 
   /**
    * Write a message to the console. Prefixed with the log type
@@ -108,16 +108,16 @@ export abstract class Logger {
    *
    * @returns Return the full logged message.
    */
-  abstract trace(message: string): string | void ;
+  abstract trace(message: string): string | void;
 
   /**
-    * Write a message to the console. Prefixed with the log type
-    *
-    * @param message - The message to be logged
-    *
-    * @returns Return the full logged message.
-    */
-  abstract fatal(message: string): string | void ;
+   * Write a message to the console. Prefixed with the log type
+   *
+   * @param message - The message to be logged
+   *
+   * @returns Return the full logged message.
+   */
+  abstract fatal(message: string): string | void;
 
   //////////////////////////////////////////////////////////////////////////////
   // FILE MARKER - METHODS - PROTECTED /////////////////////////////////////////

--- a/tests/unit/console_logger_test.ts
+++ b/tests/unit/console_logger_test.ts
@@ -1,7 +1,12 @@
 import { Rhum } from "../deps.ts";
 import { ConsoleLogger } from "../../mod.ts";
 
-const logger = new ConsoleLogger({});
+// Ensure no logging is done in the test output
+console.log = () => true;
+
+const logger = new ConsoleLogger({
+  level: "all",
+});
 
 Rhum.testPlan("tests/loggers/console_logger_test.ts", () => {
   Rhum.testSuite("info()", () => {
@@ -61,6 +66,7 @@ Rhum.testPlan("tests/loggers/console_logger_test.ts", () => {
   Rhum.testSuite("Configs", () => {
     Rhum.testCase("Uses the tag string", () => {
       const l = new ConsoleLogger({
+        level: "all",
         tag_string: "{bingo} | {bongo} |",
         tag_string_fns: {
           bingo() {
@@ -74,7 +80,7 @@ Rhum.testPlan("tests/loggers/console_logger_test.ts", () => {
       const message = l.info("This is cool!");
       Rhum.asserts.assertEquals(
         message,
-        "\x1b[32m[INFO]\x1b[39m BINGO! | BONGO :D |  This is cool!",
+        "\x1b[32m[INFO]\x1b[39m BINGO! | BONGO :D | This is cool!",
       );
     });
   });

--- a/tests/unit/file_logger_test.ts
+++ b/tests/unit/file_logger_test.ts
@@ -4,6 +4,7 @@ import { FileLogger } from "../../mod.ts";
 const file = "file_logger_test.log";
 const decoder = new TextDecoder();
 const logger = new FileLogger({
+  level: "all",
   file,
 });
 
@@ -101,6 +102,7 @@ Rhum.testPlan("tests/loggers/file_logger_test.ts", () => {
   Rhum.testSuite("Configs", () => {
     Rhum.testCase("Uses the tag string", () => {
       const l = new FileLogger({
+        level: "info",
         file,
         tag_string: "{bingo} | {bongo}",
         tag_string_fns: {
@@ -117,11 +119,11 @@ Rhum.testPlan("tests/loggers/file_logger_test.ts", () => {
       Deno.removeSync(file, { recursive: true });
       Rhum.asserts.assertEquals(
         fileContent,
-        "\x1b[32m[INFO]\x1b[39m BINGO! | BONGO :D  This is cool!\n",
+        "\x1b[32m[INFO]\x1b[39m BINGO! | BONGO :D This is cool!\n",
       );
       Rhum.asserts.assertEquals(
         message,
-        "\x1b[32m[INFO]\x1b[39m BINGO! | BONGO :D  This is cool!",
+        "\x1b[32m[INFO]\x1b[39m BINGO! | BONGO :D This is cool!",
       );
     });
   });

--- a/tests/unit/logger_test.ts
+++ b/tests/unit/logger_test.ts
@@ -7,45 +7,45 @@ console.log = () => true;
 Rhum.testPlan("tests/loggers/logger_test.ts", () => {
   Rhum.testSuite(`shouldLog("all")`, () => {
     Rhum.testCase(`logs all messages`, () => {
-      const logger = new ConsoleLogger({level: "all"});
+      const logger = new ConsoleLogger({ level: "all" });
       let message: string | void;
 
       message = logger.trace("This is cool!");
       Rhum.asserts.assertEquals(
         message,
-        "\x1b[41m[TRACE]\x1b[49m This is cool!"
+        "\x1b[41m[TRACE]\x1b[49m This is cool!",
       );
       message = logger.debug("This is cool!");
       Rhum.asserts.assertEquals(
         message,
-        "\x1b[34m[DEBUG]\x1b[39m This is cool!"
+        "\x1b[34m[DEBUG]\x1b[39m This is cool!",
       );
       message = logger.info("This is cool!");
       Rhum.asserts.assertEquals(
         message,
-        "\x1b[32m[INFO]\x1b[39m This is cool!"
+        "\x1b[32m[INFO]\x1b[39m This is cool!",
       );
       message = logger.warn("This is cool!");
       Rhum.asserts.assertEquals(
         message,
-        "\x1b[33m[WARN]\x1b[39m This is cool!"
+        "\x1b[33m[WARN]\x1b[39m This is cool!",
       );
       message = logger.error("This is cool!");
       Rhum.asserts.assertEquals(
         message,
-        "\x1b[31m[ERROR]\x1b[39m This is cool!"
+        "\x1b[31m[ERROR]\x1b[39m This is cool!",
       );
       message = logger.fatal("This is cool!");
       Rhum.asserts.assertEquals(
         message,
-        "\x1b[35m[FATAL]\x1b[39m This is cool!"
+        "\x1b[35m[FATAL]\x1b[39m This is cool!",
       );
     });
   });
 
   Rhum.testSuite(`shouldLog("off")`, () => {
     Rhum.testCase(`does not log any messages`, () => {
-      const logger = new ConsoleLogger({level: "off"});
+      const logger = new ConsoleLogger({ level: "off" });
       let message: string | void;
 
       message = logger.info("This is cool!");
@@ -83,45 +83,45 @@ Rhum.testPlan("tests/loggers/logger_test.ts", () => {
 
   Rhum.testSuite(`shouldLog("trace")`, () => {
     Rhum.testCase(`logs trace, debug, info, warn, error, and fatal`, () => {
-      const logger = new ConsoleLogger({level: "trace"});
+      const logger = new ConsoleLogger({ level: "trace" });
       let message: string | void;
 
       message = logger.trace("This is cool!");
       Rhum.asserts.assertEquals(
         message,
-        "\x1b[41m[TRACE]\x1b[49m This is cool!"
+        "\x1b[41m[TRACE]\x1b[49m This is cool!",
       );
       message = logger.debug("This is cool!");
       Rhum.asserts.assertEquals(
         message,
-        "\x1b[34m[DEBUG]\x1b[39m This is cool!"
+        "\x1b[34m[DEBUG]\x1b[39m This is cool!",
       );
       message = logger.info("This is cool!");
       Rhum.asserts.assertEquals(
         message,
-        "\x1b[32m[INFO]\x1b[39m This is cool!"
+        "\x1b[32m[INFO]\x1b[39m This is cool!",
       );
       message = logger.warn("This is cool!");
       Rhum.asserts.assertEquals(
         message,
-        "\x1b[33m[WARN]\x1b[39m This is cool!"
+        "\x1b[33m[WARN]\x1b[39m This is cool!",
       );
       message = logger.error("This is cool!");
       Rhum.asserts.assertEquals(
         message,
-        "\x1b[31m[ERROR]\x1b[39m This is cool!"
+        "\x1b[31m[ERROR]\x1b[39m This is cool!",
       );
       message = logger.fatal("This is cool!");
       Rhum.asserts.assertEquals(
         message,
-        "\x1b[35m[FATAL]\x1b[39m This is cool!"
+        "\x1b[35m[FATAL]\x1b[39m This is cool!",
       );
     });
   });
 
   Rhum.testSuite(`shouldLog("debug")`, () => {
     Rhum.testCase(`logs debug, info, warn, error, and fatal`, () => {
-      const logger = new ConsoleLogger({level: "debug"});
+      const logger = new ConsoleLogger({ level: "debug" });
       let message: string | void;
 
       message = logger.trace("This is cool!");
@@ -132,37 +132,36 @@ Rhum.testPlan("tests/loggers/logger_test.ts", () => {
       message = logger.debug("This is cool!");
       Rhum.asserts.assertEquals(
         message,
-        "\x1b[34m[DEBUG]\x1b[39m This is cool!"
+        "\x1b[34m[DEBUG]\x1b[39m This is cool!",
       );
       message = logger.info("This is cool!");
       Rhum.asserts.assertEquals(
         message,
-        "\x1b[32m[INFO]\x1b[39m This is cool!"
+        "\x1b[32m[INFO]\x1b[39m This is cool!",
       );
       message = logger.warn("This is cool!");
       Rhum.asserts.assertEquals(
         message,
-        "\x1b[33m[WARN]\x1b[39m This is cool!"
+        "\x1b[33m[WARN]\x1b[39m This is cool!",
       );
       message = logger.error("This is cool!");
       Rhum.asserts.assertEquals(
         message,
-        "\x1b[31m[ERROR]\x1b[39m This is cool!"
+        "\x1b[31m[ERROR]\x1b[39m This is cool!",
       );
       message = logger.fatal("This is cool!");
       Rhum.asserts.assertEquals(
         message,
-        "\x1b[35m[FATAL]\x1b[39m This is cool!"
+        "\x1b[35m[FATAL]\x1b[39m This is cool!",
       );
     });
   });
 
   Rhum.testSuite(`shouldLog("info")`, () => {
     Rhum.testCase(`logs info, warn, error, and fatal`, () => {
-      let logger: ConsoleLogger;
       let message: string | void;
 
-      logger = new ConsoleLogger({level: "info"});
+      const logger = new ConsoleLogger({ level: "info" });
 
       message = logger.debug("This is cool!");
       Rhum.asserts.assertEquals(
@@ -182,62 +181,24 @@ Rhum.testPlan("tests/loggers/logger_test.ts", () => {
       message = logger.warn("This is cool!");
       Rhum.asserts.assertEquals(
         message,
-        "\x1b[33m[WARN]\x1b[39m This is cool!"
+        "\x1b[33m[WARN]\x1b[39m This is cool!",
       );
       message = logger.error("This is cool!");
       Rhum.asserts.assertEquals(
         message,
-        "\x1b[31m[ERROR]\x1b[39m This is cool!"
+        "\x1b[31m[ERROR]\x1b[39m This is cool!",
       );
       message = logger.fatal("This is cool!");
       Rhum.asserts.assertEquals(
         message,
-        "\x1b[35m[FATAL]\x1b[39m This is cool!"
+        "\x1b[35m[FATAL]\x1b[39m This is cool!",
       );
     });
   });
 
   Rhum.testSuite(`shouldLog("warn")`, () => {
     Rhum.testCase(`logs warn, error, and fatal`, () => {
-      const logger = new ConsoleLogger({level: "warn"});
-      let message: string | void;
-
-      message = logger.trace("This is cool!");
-      Rhum.asserts.assertEquals(
-        message,
-        undefined,
-      );
-      message = logger.debug("This is cool!");
-      Rhum.asserts.assertEquals(
-        message,
-        undefined,
-      );
-      message = logger.info("This is cool!");
-      Rhum.asserts.assertEquals(
-        message,
-        undefined,
-      );
-      message = logger.warn("This is cool!");
-      Rhum.asserts.assertEquals(
-        message,
-        "\x1b[33m[WARN]\x1b[39m This is cool!"
-      );
-      message = logger.error("This is cool!");
-      Rhum.asserts.assertEquals(
-        message,
-        "\x1b[31m[ERROR]\x1b[39m This is cool!"
-      );
-      message = logger.fatal("This is cool!");
-      Rhum.asserts.assertEquals(
-        message,
-        "\x1b[35m[FATAL]\x1b[39m This is cool!"
-      );
-    });
-  });
-
-  Rhum.testSuite(`shouldLog("error")`, () => {
-    Rhum.testCase(`logs error and fatal`, () => {
-      const logger = new ConsoleLogger({level: "warn"});
+      const logger = new ConsoleLogger({ level: "warn" });
       let message: string | void;
 
       message = logger.trace("This is cool!");
@@ -263,19 +224,57 @@ Rhum.testPlan("tests/loggers/logger_test.ts", () => {
       message = logger.error("This is cool!");
       Rhum.asserts.assertEquals(
         message,
-        "\x1b[31m[ERROR]\x1b[39m This is cool!"
+        "\x1b[31m[ERROR]\x1b[39m This is cool!",
       );
       message = logger.fatal("This is cool!");
       Rhum.asserts.assertEquals(
         message,
-        "\x1b[35m[FATAL]\x1b[39m This is cool!"
+        "\x1b[35m[FATAL]\x1b[39m This is cool!",
       );
     });
   });
 
   Rhum.testSuite(`shouldLog("error")`, () => {
     Rhum.testCase(`logs error and fatal`, () => {
-      const logger = new ConsoleLogger({level: "error"});
+      const logger = new ConsoleLogger({ level: "warn" });
+      let message: string | void;
+
+      message = logger.trace("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        undefined,
+      );
+      message = logger.debug("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        undefined,
+      );
+      message = logger.info("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        undefined,
+      );
+      message = logger.warn("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        "\x1b[33m[WARN]\x1b[39m This is cool!",
+      );
+      message = logger.error("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        "\x1b[31m[ERROR]\x1b[39m This is cool!",
+      );
+      message = logger.fatal("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        "\x1b[35m[FATAL]\x1b[39m This is cool!",
+      );
+    });
+  });
+
+  Rhum.testSuite(`shouldLog("error")`, () => {
+    Rhum.testCase(`logs error and fatal`, () => {
+      const logger = new ConsoleLogger({ level: "error" });
       let message: string | void;
 
       message = logger.trace("This is cool!");
@@ -301,19 +300,19 @@ Rhum.testPlan("tests/loggers/logger_test.ts", () => {
       message = logger.error("This is cool!");
       Rhum.asserts.assertEquals(
         message,
-        "\x1b[31m[ERROR]\x1b[39m This is cool!"
+        "\x1b[31m[ERROR]\x1b[39m This is cool!",
       );
       message = logger.fatal("This is cool!");
       Rhum.asserts.assertEquals(
         message,
-        "\x1b[35m[FATAL]\x1b[39m This is cool!"
+        "\x1b[35m[FATAL]\x1b[39m This is cool!",
       );
     });
   });
 
   Rhum.testSuite(`shouldLog("fatal")`, () => {
     Rhum.testCase(`logs fatal`, () => {
-      const logger = new ConsoleLogger({level: "fatal"});
+      const logger = new ConsoleLogger({ level: "fatal" });
       let message: string | void;
 
       message = logger.trace("This is cool!");
@@ -344,11 +343,10 @@ Rhum.testPlan("tests/loggers/logger_test.ts", () => {
       message = logger.fatal("This is cool!");
       Rhum.asserts.assertEquals(
         message,
-        "\x1b[35m[FATAL]\x1b[39m This is cool!"
+        "\x1b[35m[FATAL]\x1b[39m This is cool!",
       );
     });
   });
 });
 
 Rhum.run();
-

--- a/tests/unit/logger_test.ts
+++ b/tests/unit/logger_test.ts
@@ -1,0 +1,354 @@
+import { Rhum } from "../deps.ts";
+import { ConsoleLogger } from "../../mod.ts";
+
+// Ensure no logging is done in the test output
+console.log = () => true;
+
+Rhum.testPlan("tests/loggers/logger_test.ts", () => {
+  Rhum.testSuite(`shouldLog("all")`, () => {
+    Rhum.testCase(`logs all messages`, () => {
+      const logger = new ConsoleLogger({level: "all"});
+      let message: string | void;
+
+      message = logger.trace("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        "\x1b[41m[TRACE]\x1b[49m This is cool!"
+      );
+      message = logger.debug("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        "\x1b[34m[DEBUG]\x1b[39m This is cool!"
+      );
+      message = logger.info("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        "\x1b[32m[INFO]\x1b[39m This is cool!"
+      );
+      message = logger.warn("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        "\x1b[33m[WARN]\x1b[39m This is cool!"
+      );
+      message = logger.error("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        "\x1b[31m[ERROR]\x1b[39m This is cool!"
+      );
+      message = logger.fatal("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        "\x1b[35m[FATAL]\x1b[39m This is cool!"
+      );
+    });
+  });
+
+  Rhum.testSuite(`shouldLog("off")`, () => {
+    Rhum.testCase(`does not log any messages`, () => {
+      const logger = new ConsoleLogger({level: "off"});
+      let message: string | void;
+
+      message = logger.info("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        undefined,
+      );
+      message = logger.debug("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        undefined,
+      );
+      message = logger.warn("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        undefined,
+      );
+      message = logger.trace("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        undefined,
+      );
+      message = logger.fatal("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        undefined,
+      );
+      message = logger.error("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        undefined,
+      );
+    });
+  });
+
+  Rhum.testSuite(`shouldLog("trace")`, () => {
+    Rhum.testCase(`logs trace, debug, info, warn, error, and fatal`, () => {
+      const logger = new ConsoleLogger({level: "trace"});
+      let message: string | void;
+
+      message = logger.trace("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        "\x1b[41m[TRACE]\x1b[49m This is cool!"
+      );
+      message = logger.debug("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        "\x1b[34m[DEBUG]\x1b[39m This is cool!"
+      );
+      message = logger.info("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        "\x1b[32m[INFO]\x1b[39m This is cool!"
+      );
+      message = logger.warn("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        "\x1b[33m[WARN]\x1b[39m This is cool!"
+      );
+      message = logger.error("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        "\x1b[31m[ERROR]\x1b[39m This is cool!"
+      );
+      message = logger.fatal("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        "\x1b[35m[FATAL]\x1b[39m This is cool!"
+      );
+    });
+  });
+
+  Rhum.testSuite(`shouldLog("debug")`, () => {
+    Rhum.testCase(`logs debug, info, warn, error, and fatal`, () => {
+      const logger = new ConsoleLogger({level: "debug"});
+      let message: string | void;
+
+      message = logger.trace("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        undefined,
+      );
+      message = logger.debug("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        "\x1b[34m[DEBUG]\x1b[39m This is cool!"
+      );
+      message = logger.info("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        "\x1b[32m[INFO]\x1b[39m This is cool!"
+      );
+      message = logger.warn("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        "\x1b[33m[WARN]\x1b[39m This is cool!"
+      );
+      message = logger.error("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        "\x1b[31m[ERROR]\x1b[39m This is cool!"
+      );
+      message = logger.fatal("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        "\x1b[35m[FATAL]\x1b[39m This is cool!"
+      );
+    });
+  });
+
+  Rhum.testSuite(`shouldLog("info")`, () => {
+    Rhum.testCase(`logs info, warn, error, and fatal`, () => {
+      let logger: ConsoleLogger;
+      let message: string | void;
+
+      logger = new ConsoleLogger({level: "info"});
+
+      message = logger.debug("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        undefined,
+      );
+      message = logger.trace("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        undefined,
+      );
+      message = logger.info("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        "\x1b[32m[INFO]\x1b[39m This is cool!",
+      );
+      message = logger.warn("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        "\x1b[33m[WARN]\x1b[39m This is cool!"
+      );
+      message = logger.error("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        "\x1b[31m[ERROR]\x1b[39m This is cool!"
+      );
+      message = logger.fatal("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        "\x1b[35m[FATAL]\x1b[39m This is cool!"
+      );
+    });
+  });
+
+  Rhum.testSuite(`shouldLog("warn")`, () => {
+    Rhum.testCase(`logs warn, error, and fatal`, () => {
+      const logger = new ConsoleLogger({level: "warn"});
+      let message: string | void;
+
+      message = logger.trace("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        undefined,
+      );
+      message = logger.debug("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        undefined,
+      );
+      message = logger.info("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        undefined,
+      );
+      message = logger.warn("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        "\x1b[33m[WARN]\x1b[39m This is cool!"
+      );
+      message = logger.error("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        "\x1b[31m[ERROR]\x1b[39m This is cool!"
+      );
+      message = logger.fatal("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        "\x1b[35m[FATAL]\x1b[39m This is cool!"
+      );
+    });
+  });
+
+  Rhum.testSuite(`shouldLog("error")`, () => {
+    Rhum.testCase(`logs error and fatal`, () => {
+      const logger = new ConsoleLogger({level: "warn"});
+      let message: string | void;
+
+      message = logger.trace("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        undefined,
+      );
+      message = logger.debug("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        undefined,
+      );
+      message = logger.info("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        undefined,
+      );
+      message = logger.warn("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        "\x1b[33m[WARN]\x1b[39m This is cool!",
+      );
+      message = logger.error("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        "\x1b[31m[ERROR]\x1b[39m This is cool!"
+      );
+      message = logger.fatal("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        "\x1b[35m[FATAL]\x1b[39m This is cool!"
+      );
+    });
+  });
+
+  Rhum.testSuite(`shouldLog("error")`, () => {
+    Rhum.testCase(`logs error and fatal`, () => {
+      const logger = new ConsoleLogger({level: "error"});
+      let message: string | void;
+
+      message = logger.trace("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        undefined,
+      );
+      message = logger.debug("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        undefined,
+      );
+      message = logger.info("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        undefined,
+      );
+      message = logger.warn("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        undefined,
+      );
+      message = logger.error("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        "\x1b[31m[ERROR]\x1b[39m This is cool!"
+      );
+      message = logger.fatal("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        "\x1b[35m[FATAL]\x1b[39m This is cool!"
+      );
+    });
+  });
+
+  Rhum.testSuite(`shouldLog("fatal")`, () => {
+    Rhum.testCase(`logs fatal`, () => {
+      const logger = new ConsoleLogger({level: "fatal"});
+      let message: string | void;
+
+      message = logger.trace("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        undefined,
+      );
+      message = logger.debug("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        undefined,
+      );
+      message = logger.info("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        undefined,
+      );
+      message = logger.warn("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        undefined,
+      );
+      message = logger.error("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        undefined,
+      );
+      message = logger.fatal("This is cool!");
+      Rhum.asserts.assertEquals(
+        message,
+        "\x1b[35m[FATAL]\x1b[39m This is cool!"
+      );
+    });
+  });
+});
+
+Rhum.run();
+


### PR DESCRIPTION
## Summary

Added `level` config to set log level to one of the following:

```
all
trace
debug
info
warn
error
fatal
```

When `level` is set to one of the following, it logs everything with a lower rank:

```
all: logs all messages
trace: logs trace, debug, info, warn, error, fatal
debug: logs debug, info, warn, error, fatal
info: logs info, warn, error, fatal
warn: logs warn, error, fatal,
error: logs error, fatal
fatal: logs fatal
off: does not log any messages
```